### PR TITLE
Pickle input to S3

### DIFF
--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -47,7 +47,7 @@ def get_s3_bucket():
 
     option = 's3-bucket'
     if config.has_section('aws') and config.has_option('aws', option):
-        return config.get('aws', option)
+        bucket = config.get('aws', option)
     else:
         # Set `bucket`, the fallback bucket in case the cloudknot
         # bucket environment variable is not set
@@ -58,11 +58,11 @@ def get_s3_bucket():
             bucket = ('cloudknot-' + getpass.getuser().lower()
                       + '-' + str(uuid.uuid4()))
 
-        # Use set_s3_bucket to check for name availability
-        # and write to config file
-        set_s3_bucket(bucket)
+    # Use set_s3_bucket to check for name availability
+    # and write to config file
+    set_s3_bucket(bucket)
 
-        return bucket
+    return bucket
 
 
 def set_s3_bucket(bucket):
@@ -123,16 +123,16 @@ def get_bucket_policy(bucket):
             },
             {
                 "Effect": "Allow",
-                "Action": ["s3:PutObject"],
+                "Action": ["s3:PutObject", "s3:GetObject"],
                 "Resource": ["arn:aws:s3:::{0:s}/*".format(bucket)]
-            }
+            },
         ]
     }
 
     return s3_policy
 
 
-def get_s3_policy_name():
+def get_s3_policy_name(bucket):
     """Get the policy that grants access to the cloudknot S3 bucket
 
     First, check the cloudknot config file for the bucket-policy option.
@@ -162,7 +162,6 @@ def get_s3_policy_name():
         with open(config_file, 'w') as f:
             config.write(f)
 
-    bucket = get_s3_bucket()
     s3_policy = get_bucket_policy(bucket)
 
     try:
@@ -189,7 +188,7 @@ def update_s3_policy(bucket):
         Amazon S3 bucket name
     """
     s3_policy = get_bucket_policy(bucket)
-    policy = get_s3_policy_name()
+    policy = get_s3_policy_name(bucket)
 
     # After calling get_s3_policy_name(), the policy already exists
     # Get the ARN

--- a/cloudknot/aws/iam.py
+++ b/cloudknot/aws/iam.py
@@ -7,7 +7,8 @@ import six
 import tenacity
 from collections import namedtuple
 
-from .base_classes import ObjectWithArn, clients, get_s3_policy_name, \
+from .base_classes import ObjectWithArn, clients, \
+    get_s3_bucket, get_s3_policy_name, \
     ResourceExistsException, ResourceDoesNotExistException, \
     ResourceClobberedException, CannotDeleteResourceException
 
@@ -142,7 +143,10 @@ class IamRole(ObjectWithArn):
                 )
 
             # Add the cloudknot s3 policy if not already in input_policies
-            self._policies = tuple(input_policies | {get_s3_policy_name()})
+            bucket = get_s3_bucket()
+            self._policies = tuple(
+                input_policies | {get_s3_policy_name(bucket)}
+            )
 
             if not isinstance(add_instance_profile, bool):
                 raise ValueError('add_instance_profile is a boolean input')

--- a/cloudknot/data/docker_reqs_ref_data/py2/ref1/requirements.txt
+++ b/cloudknot/data/docker_reqs_ref_data/py2/ref1/requirements.txt
@@ -1,5 +1,4 @@
 boto3==1.4.7
-clize==4.0.1
 cloudpickle==0.4.1
 dask==0.15.3
 docker==2.5.1

--- a/cloudknot/data/docker_reqs_ref_data/py2/ref1/unit_testing_func.py
+++ b/cloudknot/data/docker_reqs_ref_data/py2/ref1/unit_testing_func.py
@@ -1,7 +1,8 @@
 import boto3
 import cloudpickle
 import os
-from clize import run
+import pickle
+from argparse import ArgumentParser
 from functools import wraps
 
 
@@ -53,4 +54,36 @@ def unit_testing_func(name=None, no_capitalize=False):
 
 
 if __name__ == "__main__":
-    run(unit_testing_func)
+    description = ('Download input from an S3 bucket and provide that input '
+                   'to our function. On return put output in an S3 bucket.')
+
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument(
+        'bucket', metavar='bucket', type=str,
+        help='The S3 bucket for pulling input and pushing output.'
+    )
+
+    parser.add_argument(
+        '--starmap', action='store_true',
+        help='Assume input has already been grouped into a single tuple.'
+    )
+
+    args = parser.parse_args()
+
+    s3 = boto3.client('s3')
+    bucket = args.bucket
+    key = '/'.join([
+        'cloudknot.jobs',
+        os.environ.get("CLOUDKNOT_S3_JOBDEF_KEY"),
+        os.environ.get("AWS_BATCH_JOB_ID"),
+        'input.pickle'
+    ])
+
+    response = s3.get_object(Bucket=bucket, Key=key)
+    input = pickle.loads(response.get('Body').read())
+
+    if args.starmap:
+        unit_testing_func(*input)
+    else:
+        unit_testing_func(input)

--- a/cloudknot/data/docker_reqs_ref_data/py2/ref2/requirements.txt
+++ b/cloudknot/data/docker_reqs_ref_data/py2/ref2/requirements.txt
@@ -1,4 +1,3 @@
-clize==4.0.1
 boto3==1.4.7
 cloudpickle==0.4.1
 six==1.11.0

--- a/cloudknot/data/docker_reqs_ref_data/py2/ref2/test_func_input.py
+++ b/cloudknot/data/docker_reqs_ref_data/py2/ref2/test_func_input.py
@@ -1,7 +1,8 @@
 import boto3
 import cloudpickle
 import os
-from clize import run
+import pickle
+from argparse import ArgumentParser
 from functools import wraps
 
 
@@ -52,4 +53,36 @@ def unit_testing_func(name=None, no_capitalize=False):
 
 
 if __name__ == "__main__":
-    run(unit_testing_func)
+    description = ('Download input from an S3 bucket and provide that input '
+                   'to our function. On return put output in an S3 bucket.')
+
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument(
+        'bucket', metavar='bucket', type=str,
+        help='The S3 bucket for pulling input and pushing output.'
+    )
+
+    parser.add_argument(
+        '--starmap', action='store_true',
+        help='Assume input has already been grouped into a single tuple.'
+    )
+
+    args = parser.parse_args()
+
+    s3 = boto3.client('s3')
+    bucket = args.bucket
+    key = '/'.join([
+        'cloudknot.jobs',
+        os.environ.get("CLOUDKNOT_S3_JOBDEF_KEY"),
+        os.environ.get("AWS_BATCH_JOB_ID"),
+        'input.pickle'
+    ])
+
+    response = s3.get_object(Bucket=bucket, Key=key)
+    input = pickle.loads(response.get('Body').read())
+
+    if args.starmap:
+        unit_testing_func(*input)
+    else:
+        unit_testing_func(input)

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref1/requirements.txt
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref1/requirements.txt
@@ -1,5 +1,4 @@
 boto3==1.4.7
-clize==4.0.1
 cloudpickle==0.4.1
 dask==0.15.3
 docker==2.5.1

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref1/unit_testing_func.py
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref1/unit_testing_func.py
@@ -1,7 +1,8 @@
 import boto3
 import cloudpickle
 import os
-from clize import run
+import pickle
+from argparse import ArgumentParser
 from functools import wraps
 
 
@@ -53,4 +54,36 @@ def unit_testing_func(name=None, no_capitalize=False):
 
 
 if __name__ == "__main__":
-    run(unit_testing_func)
+    description = ('Download input from an S3 bucket and provide that input '
+                   'to our function. On return put output in an S3 bucket.')
+
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument(
+        'bucket', metavar='bucket', type=str,
+        help='The S3 bucket for pulling input and pushing output.'
+    )
+
+    parser.add_argument(
+        '--starmap', action='store_true',
+        help='Assume input has already been grouped into a single tuple.'
+    )
+
+    args = parser.parse_args()
+
+    s3 = boto3.client('s3')
+    bucket = args.bucket
+    key = '/'.join([
+        'cloudknot.jobs',
+        os.environ.get("CLOUDKNOT_S3_JOBDEF_KEY"),
+        os.environ.get("AWS_BATCH_JOB_ID"),
+        'input.pickle'
+    ])
+
+    response = s3.get_object(Bucket=bucket, Key=key)
+    input = pickle.loads(response.get('Body').read())
+
+    if args.starmap:
+        unit_testing_func(*input)
+    else:
+        unit_testing_func(input)

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/requirements.txt
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/requirements.txt
@@ -1,4 +1,3 @@
-clize==4.0.1
 boto3==1.4.7
 cloudpickle==0.4.1
 six==1.11.0

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/test_func_input.py
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/test_func_input.py
@@ -1,7 +1,8 @@
 import boto3
 import cloudpickle
 import os
-from clize import run
+import pickle
+from argparse import ArgumentParser
 from functools import wraps
 
 
@@ -52,4 +53,36 @@ def unit_testing_func(name=None, no_capitalize=False):
 
 
 if __name__ == "__main__":
-    run(unit_testing_func)
+    description = ('Download input from an S3 bucket and provide that input '
+                   'to our function. On return put output in an S3 bucket.')
+
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument(
+        'bucket', metavar='bucket', type=str,
+        help='The S3 bucket for pulling input and pushing output.'
+    )
+
+    parser.add_argument(
+        '--starmap', action='store_true',
+        help='Assume input has already been grouped into a single tuple.'
+    )
+
+    args = parser.parse_args()
+
+    s3 = boto3.client('s3')
+    bucket = args.bucket
+    key = '/'.join([
+        'cloudknot.jobs',
+        os.environ.get("CLOUDKNOT_S3_JOBDEF_KEY"),
+        os.environ.get("AWS_BATCH_JOB_ID"),
+        'input.pickle'
+    ])
+
+    response = s3.get_object(Bucket=bucket, Key=key)
+    input = pickle.loads(response.get('Body').read())
+
+    if args.starmap:
+        unit_testing_func(*input)
+    else:
+        unit_testing_func(input)

--- a/cloudknot/script.template
+++ b/cloudknot/script.template
@@ -1,7 +1,8 @@
 import boto3
 import cloudpickle
 import os
-from clize import run
+import pickle
+from argparse import ArgumentParser
 from functools import wraps
 
 
@@ -27,4 +28,36 @@ def pickle_to_s3(f):
 ${func_source}
 
 if __name__ == "__main__":
-    run(${func_name})
+    description = ('Download input from an S3 bucket and provide that input '
+                   'to our function. On return put output in an S3 bucket.')
+
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument(
+        'bucket', metavar='bucket', type=str,
+        help='The S3 bucket for pulling input and pushing output.'
+    )
+
+    parser.add_argument(
+        '--starmap', action='store_true',
+        help='Assume input has already been grouped into a single tuple.'
+    )
+
+    args = parser.parse_args()
+
+    s3 = boto3.client('s3')
+    bucket = args.bucket
+    key = '/'.join([
+        'cloudknot.jobs',
+        os.environ.get("CLOUDKNOT_S3_JOBDEF_KEY"),
+        os.environ.get("AWS_BATCH_JOB_ID"),
+        'input.pickle'
+    ])
+
+    response = s3.get_object(Bucket=bucket, Key=key)
+    input = pickle.loads(response.get('Body').read())
+
+    if args.starmap:
+        ${func_name}(*input)
+    else:
+        ${func_name}(input)

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -2500,6 +2500,7 @@ def test_BatchJob(pars):
         with pytest.raises(ValueError):
             ck.aws.BatchJob(
                 name=get_testing_name(),
+                input=42,
                 job_queue=42
             )
 
@@ -2507,23 +2508,16 @@ def test_BatchJob(pars):
         with pytest.raises(ValueError):
             ck.aws.BatchJob(
                 name=get_testing_name(),
+                input=42,
                 job_queue=job_queue,
                 job_definition=42
             )
 
-        # Assert ValueError on invalid commands
+        # Assert ValueError on invalid environment variable
         with pytest.raises(ValueError):
             ck.aws.BatchJob(
                 name=get_testing_name(),
-                job_queue=job_queue,
-                job_definition=job_def,
-                commands=[42, 42]
-            )
-
-        # Assert ValueError on invalid commands
-        with pytest.raises(ValueError):
-            ck.aws.BatchJob(
-                name=get_testing_name(),
+                input=42,
                 job_queue=job_queue,
                 job_definition=job_def,
                 environment_variables=42

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -52,7 +52,7 @@ def bucket_cleanup():
                      '4b27-9a40-672c971f7e83')
     yield None
     bucket = ck.get_s3_bucket()
-    bucket_policy = ck.aws.base_classes.get_s3_policy_name()
+    bucket_policy = ck.aws.base_classes.get_s3_policy_name(bucket)
 
     s3 = ck.aws.clients['s3']
     s3.delete_bucket(Bucket=bucket)
@@ -601,8 +601,9 @@ def test_IamRole(bucket_cleanup):
             assert role.description == d
             assert role.service == s + '.amazonaws.com'
             p = (p,) if isinstance(p, six.string_types) else tuple(p)
+            bucket = ck.get_s3_bucket()
             assert set(role.policies) == (
-                set(p) | {ck.aws.base_classes.get_s3_policy_name()}
+                set(p) | {ck.aws.base_classes.get_s3_policy_name(bucket)}
             )
             if i:
                 assert role.instance_profile_arn

--- a/cloudknot/tests/test_cloudknot_dockerimage.py
+++ b/cloudknot/tests/test_cloudknot_dockerimage.py
@@ -28,7 +28,7 @@ def bucket_cleanup():
                      '4b27-9a40-672c971f7e83')
     yield None
     bucket = ck.get_s3_bucket()
-    bucket_policy = ck.aws.base_classes.get_s3_policy_name()
+    bucket_policy = ck.aws.base_classes.get_s3_policy_name(bucket)
 
     s3 = ck.aws.clients['s3']
     s3.delete_bucket(Bucket=bucket)

--- a/cloudknot/tests/test_cloudknot_dockerimage.py
+++ b/cloudknot/tests/test_cloudknot_dockerimage.py
@@ -802,7 +802,7 @@ def test_DockerImage(cleanup_repos):
 
     try:
         correct_pip_imports = set([
-            'clize', 'boto3', 'six', 'dask', 'docker',
+            'boto3', 'six', 'dask', 'docker',
             'pytest', 'h5py', 'cloudpickle'
         ])
 

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -14,9 +14,11 @@ For more detail, you can familiarize yourself with the `components of AWS Batch
 <http://docs.aws.amazon.com/batch/latest/userguide/what-is-batch.html>`_.
 `Knot` instantiation creates the required AWS resources. You can build a `Knot`
 on top of a customized `Pars` (see below) or just use the default `Pars`
-(default behavior). You can submit and view jobs using the `map`, `get_jobs`
-and `view_jobs` methods. In particular, `map` returns a list of futures for
-each submitted job's results. To see `Knot` in action, see :ref:`eg-label`.
+(default behavior). You can submit and view jobs using the `map` and `view_jobs`
+methods. In particular, `map` returns a list of futures for each submitted job's
+results. You can also inspect the :class:`cloudknot.aws.BatchJob` instance for
+each job by accessing the knot's `jobs` parameter. To see `Knot` in action,
+see :ref:`eg-label`.
 
 .. container:: toggle
 

--- a/examples/a_bunch_of_hellos.ipynb
+++ b/examples/a_bunch_of_hellos.ipynb
@@ -40,7 +40,7 @@
     "editable": true
    },
    "source": [
-    "First, we write the python script that we want to run on AWS batch. Note that we import the necessary python packages within the function `hello_array`. Also note that we convert the input into an `int`. By default, all the arguments are treated as strings because they come from command line arguments via the `docker run` command in the AWS ECS task. You can change this behavior by [converting arguments](https://clize.readthedocs.io/en/stable/basics.html#converting-arguments) (links to the `clize` docs)."
+    "First, we write the python script that we want to run on AWS batch. Note that we import the necessary python packages within the function `hello_array`."
    ]
   },
   {

--- a/examples/a_bunch_of_hellos.ipynb
+++ b/examples/a_bunch_of_hellos.ipynb
@@ -7,7 +7,7 @@
     "editable": true
    },
    "source": [
-    "# Using cloudknot to batch write files to an S3 bucket"
+    "# Using cloudknot to output an array of \"hello\" strings"
    ]
   },
   {
@@ -72,7 +72,7 @@
     "editable": true
    },
    "source": [
-    "Create a knot using the `hello_array` function and a job definition memory of 1000 MiB."
+    "Create a knot using the `hello_array` function and a job definition memory of 128 MiB."
    ]
   },
   {
@@ -85,11 +85,12 @@
    },
    "outputs": [],
    "source": [
-    "knot = ck.Knot(name='hello_array', func=hello_array, memory=1000)\n",
-    "\n",
-    "# If you previously created this knot but didn't clobber it, then just supply\n",
-    "# the name in order to retrieve the knot info from the cloudknot config file\n",
-    "# knot = ck.Knot(name='hello_array')"
+    "try:\n",
+    "    knot = ck.Knot(name='hello_array', func=hello_array, memory=128)\n",
+    "except ValueError:\n",
+    "    # If you previously created this knot but didn't clobber it,\n",
+    "    # then this except clause will try to retrieve it\n",
+    "    knot = ck.Knot(name='hello_array')"
    ]
   },
   {
@@ -99,7 +100,7 @@
     "editable": true
    },
    "source": [
-    "Submit 10 batch jobs to the knot. `commands` must be a sequence of commands and each command must be a sequence of strings. Therefore, `commands` must be a sequence of sequences of strings. For example, if you wanted to pass three commands `echo 1`, `echo 2`, `echo 3`, then then you would use `submit(commands=[[\"echo\", \"1\"], [\"echo\", \"2\"], [\"echo\", \"3\"]])`. The commands must be strings because they will eventually be passed to our command line interface via the `docker run` command."
+    "Submit 10 batch jobs to the knot. The `map()` method returns a list of futures for the results of each batch job."
    ]
   },
   {
@@ -110,39 +111,9 @@
     "deletable": true,
     "editable": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[['0'], ['1'], ['2'], ['3'], ['4'], ['5'], ['6'], ['7'], ['8'], ['9']]\n"
-     ]
-    }
-   ],
-   "source": [
-    "n_commands = 10\n",
-    "commands = [[str(i)] for i in range(n_commands)]\n",
-    "print(commands)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `map()` method returns a list of futures for the results of each batch job."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
    "outputs": [],
    "source": [
-    "result_futures = knot.map(commands=commands)"
+    "result_futures = knot.map(range(10))"
    ]
   },
   {
@@ -152,22 +123,12 @@
     "editable": true
    },
    "source": [
-    "We can query the jobs associated with this knot by calling `knot.get_jobs()` and `knot.view_jobs()`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "`view_jobs()` prints a bunch of job info and provides a more consice summary of job statuses."
+    "We can query the jobs associated with this knot by calling `knot.view_jobs()`, prints a bunch of job info and provides a consice summary of job statuses."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -180,16 +141,16 @@
      "text": [
       "Job ID              Name                        Status   \n",
       "---------------------------------------------------------\n",
-      "12f3e2f4-eec7-4b94-ae04-ce5c59429031        hello_array-0               SUCCEEDED\n",
-      "dc752333-adb7-41f0-a327-4bc2897a51b4        hello_array-1               SUCCEEDED\n",
-      "5c517986-f7b4-4fc0-ac80-6a91a77fd7a8        hello_array-2               SUCCEEDED\n",
-      "9a6f1a8c-b9e1-46eb-a9b5-5ee01cbbc345        hello_array-3               SUCCEEDED\n",
-      "a4c14239-a9a4-48d9-8fda-4d6d9a3556da        hello_array-4               SUCCEEDED\n",
-      "be9e1bbd-c233-4dd2-83bd-fe6c6bf7f429        hello_array-5               SUCCEEDED\n",
-      "80add267-5774-4cdf-8f99-dd7e431fe4ea        hello_array-6               SUCCEEDED\n",
-      "069121fd-03df-4540-92be-1e115bdbf2ad        hello_array-7               SUCCEEDED\n",
-      "b1519e12-73f5-48f9-974b-927a302081aa        hello_array-8               SUCCEEDED\n",
-      "11385165-e746-4ca5-8d36-f29536a27926        hello_array-9               SUCCEEDED\n"
+      "8f6ec669-530b-4776-b348-0966496e01cd        hello_array-5               SUCCEEDED\n",
+      "3d6a91a8-d1bc-4a08-9f71-e30b22e4475e        hello_array-1               SUCCEEDED\n",
+      "e44e8d44-b9ab-4940-9fb7-67914abbf5ba        hello_array-2               SUCCEEDED\n",
+      "f3208818-5486-40e3-a7a5-e05e464774b0        hello_array-9               SUCCEEDED\n",
+      "fe9f976b-a8a0-41d9-a06f-0904eadc0b7c        hello_array-3               SUCCEEDED\n",
+      "2ca59846-600f-41fc-9450-145224e7e205        hello_array-7               SUCCEEDED\n",
+      "1e207907-8fff-4593-ad96-7ea89a0c45f5        hello_array-6               SUCCEEDED\n",
+      "a5906481-5150-42b2-bf4c-8aa0b14eb73c        hello_array-8               SUCCEEDED\n",
+      "2ea7cc44-749f-4b60-8391-05248aca7495        hello_array-4               SUCCEEDED\n",
+      "72add95c-48ec-4359-b3e3-4f3ccbbaa5b6        hello_array-0               SUCCEEDED\n"
      ]
     }
    ],
@@ -205,165 +166,12 @@
     "editable": true
    },
    "source": [
-    " `get_jobs()` returns a dictionary of jobs info with `BatchJob` instances that you can interact with programatically."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/ee801bf5-d8a3-47c3-ad7f-752ee16882b2',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/ee801bf5-d8a3-47c3-ad7f-752ee16882b2'},\n",
-       "    'startedAt': 1510016241929,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016243401}],\n",
-       "  'id': '12f3e2f4-eec7-4b94-ae04-ce5c59429031',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x10679cac8>,\n",
-       "  'name': 'hello_array-0',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/19e01977-810a-48db-beff-991aa0df1c03',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/19e01977-810a-48db-beff-991aa0df1c03'},\n",
-       "    'startedAt': 1510016240506,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016241949}],\n",
-       "  'id': 'dc752333-adb7-41f0-a327-4bc2897a51b4',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x106804c50>,\n",
-       "  'name': 'hello_array-1',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/53b91485-6ec5-4403-9f7c-32f813d9e093',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/53b91485-6ec5-4403-9f7c-32f813d9e093'},\n",
-       "    'startedAt': 1510016283976,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016284930}],\n",
-       "  'id': '5c517986-f7b4-4fc0-ac80-6a91a77fd7a8',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x105e6da90>,\n",
-       "  'name': 'hello_array-2',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/6fb5246c-94a5-42a6-9206-068fa86ddd2d',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/6fb5246c-94a5-42a6-9206-068fa86ddd2d'},\n",
-       "    'startedAt': 1510016238903,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016239967}],\n",
-       "  'id': '9a6f1a8c-b9e1-46eb-a9b5-5ee01cbbc345',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x106836dd8>,\n",
-       "  'name': 'hello_array-3',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/06bbb99f-9c52-4f6e-acd6-f8607935886b',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/06bbb99f-9c52-4f6e-acd6-f8607935886b'},\n",
-       "    'startedAt': 1510016239902,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016241668}],\n",
-       "  'id': 'a4c14239-a9a4-48d9-8fda-4d6d9a3556da',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x106818898>,\n",
-       "  'name': 'hello_array-4',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/be4edb34-a737-4415-ab30-347081c3a09a',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/be4edb34-a737-4415-ab30-347081c3a09a'},\n",
-       "    'startedAt': 1510016283760,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016284690}],\n",
-       "  'id': 'be9e1bbd-c233-4dd2-83bd-fe6c6bf7f429',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x106841668>,\n",
-       "  'name': 'hello_array-5',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/16b55f72-b2a6-4dda-8a24-9b01c16b135a',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/16b55f72-b2a6-4dda-8a24-9b01c16b135a'},\n",
-       "    'startedAt': 1510016242229,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016243540}],\n",
-       "  'id': '80add267-5774-4cdf-8f99-dd7e431fe4ea',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x10683d9b0>,\n",
-       "  'name': 'hello_array-6',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/08265453-ec6f-4223-90cc-f9e9b2fa804a',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/08265453-ec6f-4223-90cc-f9e9b2fa804a'},\n",
-       "    'startedAt': 1510016241504,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016243540}],\n",
-       "  'id': '069121fd-03df-4540-92be-1e115bdbf2ad',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x1067fb668>,\n",
-       "  'name': 'hello_array-7',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/bc7bf9e4-5da3-4764-a83d-097e0f95b3c3',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/bc7bf9e4-5da3-4764-a83d-097e0f95b3c3'},\n",
-       "    'startedAt': 1510016239289,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016240934}],\n",
-       "  'id': 'b1519e12-73f5-48f9-974b-927a302081aa',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x10684e470>,\n",
-       "  'name': 'hello_array-8',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'},\n",
-       " {'attempts': [{'container': {'containerInstanceArn': 'arn:aws:ecs:us-east-1:455598791984:container-instance/ad1a7d9c-9286-442f-87be-9bb602a30de1',\n",
-       "     'exitCode': 0,\n",
-       "     'logStreamName': 'hello_array-cloudknot-job-definition/default/f1f4bdc3-8a33-448f-b4b4-979ca31279a5',\n",
-       "     'taskArn': 'arn:aws:ecs:us-east-1:455598791984:task/f1f4bdc3-8a33-448f-b4b4-979ca31279a5'},\n",
-       "    'startedAt': 1510016240731,\n",
-       "    'statusReason': 'Essential container in task exited',\n",
-       "    'stoppedAt': 1510016242232}],\n",
-       "  'id': '11385165-e746-4ca5-8d36-f29536a27926',\n",
-       "  'job': <cloudknot.aws.batch.BatchJob at 0x10679cc50>,\n",
-       "  'name': 'hello_array-9',\n",
-       "  'status': 'SUCCEEDED',\n",
-       "  'status-reason': 'Essential container in task exited'}]"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "knot.get_jobs()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
     "We can also inspect each BatchJob instance by looking at `knot.jobs` which returns a list of BatchJob instances for each submitted job, e.g.:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -376,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -388,7 +196,7 @@
      "output_type": "stream",
      "text": [
       "True\n",
-      "{'array': ['hello', 'hello', 'hello', 'hello', 'hello', 'hello', 'hello', 'hello', 'hello'], 'host': 'ip-172-31-32-84'}\n"
+      "{'array': ['hello', 'hello', 'hello', 'hello', 'hello', 'hello', 'hello', 'hello', 'hello'], 'host': 'ip-172-31-51-19'}\n"
      ]
     }
    ],
@@ -399,14 +207,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "If something goes wrong, you may want to view the AWS batch job logs on Cloudwatch. You can get the URL for a job's logs with the `BatchJob.log_urls` parameter. If the job suceeded, the log page might simply say \"no events found.\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -417,7 +228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=hello_array-cloudknot-job-definition/default/f1f4bdc3-8a33-448f-b4b4-979ca31279a5']\n"
+      "['https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=hello_array-cloudknot-job-definition/default/10227567-3c30-417e-a9e3-af3677b6bd90']\n"
      ]
     }
    ],
@@ -427,29 +238,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "`Knot.map()` returns a list of futures so you can use any of the futures methods to query the results, e.g. `done()` or `result()`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
     "editable": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "True\n",
-      "{'array': [], 'host': 'ip-172-31-32-84'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(result_futures[0].done())\n",
     "print(result_futures[0].result())"
@@ -467,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false,
     "deletable": true,

--- a/examples/using_dockerimage.ipynb
+++ b/examples/using_dockerimage.ipynb
@@ -78,7 +78,7 @@
     "editable": true
    },
    "source": [
-    "Create a test function, `test_func`, that `DockerImage` will dockerize. `DockerImage` uses [`clize`](https://clize.readthedocs.io/en/stable/) to convert the input function argument into a command line interface. By default, it will treat all of your parameters as positional parameters. But you can change this behavior, e.g. by  [accepting options](https://clize.readthedocs.io/en/stable/basics.html#accepting-options). Read the `clize` docs for more detail."
+    "Create a test function, `test_func`, that `DockerImage` will dockerize."
    ]
   },
   {
@@ -143,15 +143,15 @@
      "output_type": "stream",
      "text": [
       "test_func\n",
-      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_64jlqna1\n",
-      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_64jlqna1/requirements.txt\n",
-      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_64jlqna1/Dockerfile\n",
-      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_64jlqna1/test_func.py\n",
-      "[{'version': '1.4.7', 'name': 'boto3'}, {'version': '4.0.1', 'name': 'clize'}, {'version': '0.15.4', 'name': 'dask'}, {'version': '2.5.1', 'name': 'docker'}, {'version': '2.7.1', 'name': 'h5py'}, {'version': '3.2.3', 'name': 'pytest'}, {'version': '1.11.0', 'name': 'six'}]\n",
+      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_4vkenxtc\n",
+      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_4vkenxtc/requirements.txt\n",
+      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_4vkenxtc/Dockerfile\n",
+      "/Users/Adam/code/projects/cloudknot/examples/cloudknot_docker_test_func_4vkenxtc/test_func.py\n",
+      "[{'name': 'boto3', 'version': '1.4.7'}, {'name': 'cloudpickle', 'version': '0.4.1'}, {'name': 'dask', 'version': '0.15.4'}, {'name': 'docker', 'version': '2.5.1'}, {'name': 'h5py', 'version': '2.7.1'}, {'name': 'pytest', 'version': '3.2.3'}, {'name': 'six', 'version': '1.11.0'}]\n",
       "['https://github.com/yeatmanlab/pyAFQ.git']\n",
       "['AFQ']\n",
       "cloudknot-user\n",
-      "<function test_func at 0x109fdb1e0>\n"
+      "<function test_func at 0x113e36d08>\n"
      ]
     }
    ],
@@ -366,7 +366,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": []

--- a/examples/write_to_s3_bucket.ipynb
+++ b/examples/write_to_s3_bucket.ipynb
@@ -155,30 +155,7 @@
     "editable": true
    },
    "source": [
-    "We can query the jobs associated with this knot by calling `knot.get_jobs()` and `knot.view_jobs()`. `get_jobs()` returns a dictionary of jobs info with `BatchJob` instances that you can interact with programatically."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "knot.get_jobs()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "`view_jobs()` prints a bunch of job info and provides a more consice summary of job statuses."
+    "We can query the jobs associated with this knot by calling `knot.view_jobs()`, prints a bunch of job info and provides a consice summary of job statuses."
    ]
   },
   {

--- a/examples/write_to_s3_bucket.ipynb
+++ b/examples/write_to_s3_bucket.ipynb
@@ -93,13 +93,14 @@
    },
    "outputs": [],
    "source": [
-    "knot = ck.Knot(name='write_to_s3_bucket',\n",
-    "               func=write_to_bucket,\n",
-    "               pars_policies=('AmazonS3FullAccess',))\n",
-    "\n",
-    "# If you previously created this knot but didn't clobber it, then just supply\n",
-    "# the name in order to retrieve the knot info from the cloudknot config file\n",
-    "# knot = ck.Knot(name='test_s3_knot')"
+    "try:\n",
+    "    knot = ck.Knot(name='write_to_s3_bucket',\n",
+    "                   func=write_to_bucket,\n",
+    "                   pars_policies=('AmazonS3FullAccess',))\n",
+    "except ValueError:    \n",
+    "    # If you previously created this knot but didn't clobber it, then just supply\n",
+    "    # the name in order to retrieve the knot info from the cloudknot config file\n",
+    "    knot = ck.Knot(name='test_s3_knot')"
    ]
   },
   {
@@ -109,30 +110,7 @@
     "editable": true
    },
    "source": [
-    "Submit 10 batch jobs to the knot. `commands` must be a sequence of commands and each command must be a sequence of strings. Therefore, `commands` must be a sequence of sequences of strings. For example, if you wanted to pass three commands `echo 1`, `echo 2`, `echo 3`, then then you would use `submit(commands=[[\"echo\", \"1\"], [\"echo\", \"2\"], [\"echo\", \"3\"]])`. The commands must be strings because they will eventually be passed to our command line interface via the `docker run` command."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[['0'], ['1'], ['2'], ['3'], ['4'], ['5'], ['6'], ['7'], ['8'], ['9']]\n"
-     ]
-    }
-   ],
-   "source": [
-    "n_commands = 10\n",
-    "commands = [[str(i)] for i in range(n_commands)]\n",
-    "print(commands)"
+    "Submit 10 batch jobs to the knot."
    ]
   },
   {
@@ -145,7 +123,7 @@
    },
    "outputs": [],
    "source": [
-    "knot.map(commands=commands)"
+    "result_futures = knot.map(range(10))"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 awscli
 boto3
+cloudpickle
 docker>=2.0.0
 pipreqs
 six


### PR DESCRIPTION
Simplify input for knot.map. Send input to S3 and pull from there to the ECS containers. This gits rid of the awkward command string formatting and allows more complicated intput iterables for knot.map. Also, fix the automatic wait issue on knot.map return