### PR TITLE
Remove ValueError on retrieving pre-existing Knot with parameters

### DIFF
--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -892,10 +892,16 @@ class Knot(aws.NamedObject):
                 desired_vcpus, image_id, ec2_key_pair, ce_tags, bid_percentage,
                 job_queue_name, priority
             ]):
-                raise ValueError('You specified configuration arguments for '
-                                 'a knot that already exists. To create a '
-                                 'new knot, please choose a new name or '
-                                 'clobber the pre-existing knot.')
+                mod_logger.warning(
+                    "You specified configuration arguments for a knot that "
+                    "already exists. Cloudknot has returned the pre-existing "
+                    "knot, ignoring all of your other input parameters, which "
+                    "may or may not be the same. You should proceed with "
+                    "caution and confirm that this knot's parameters are as "
+                    "expected. If you want to be extra-safe, choose a "
+                    "different name or clobber this pre-existing knot and "
+                    "instantiate a new one with your input arguments."
+                )
 
             mod_logger.info('Found knot {name:s} in config'.format(name=name))
 

--- a/cloudknot/tests/test_cloudknot_dockerimage.py
+++ b/cloudknot/tests/test_cloudknot_dockerimage.py
@@ -1217,10 +1217,6 @@ def test_Knot(cleanup_repos):
         name = get_testing_name()
         knot = ck.Knot(name=name, pars=pars, func=unit_testing_func)
 
-        # Assert ValueError for supplying kwargs to pre-existing knot
-        with pytest.raises(ValueError):
-            ck.Knot(name=name, func=unit_testing_func)
-
         # Now remove the images and repo-uri from the docker-image
         # Forcing the next call to Knot to rebuild and re-push the image.
         config = configparser.ConfigParser()


### PR DESCRIPTION
Raise a warning instead and return the pre-existing Knot.

Resolves #96