### PR TITLE
WIP: Allow pre-existing buckets that user does not own

### DIFF
--- a/cloudknot/__init__.py
+++ b/cloudknot/__init__.py
@@ -13,7 +13,7 @@ from . import config  # noqa
 from .aws.base_classes import get_profile, set_profile, list_profiles  # noqa
 from .aws.base_classes import get_region, set_region  # noqa
 from .aws.base_classes import get_ecr_repo, set_ecr_repo  # noqa
-from .aws.base_classes import get_s3_bucket, set_s3_bucket  # noqa
+from .aws.base_classes import get_s3_params, set_s3_params  # noqa
 from .aws.base_classes import refresh_clients  # noqa
 from .cloudknot import *  # noqa
 from .dockerimage import *  # noqa

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -161,7 +161,6 @@ def get_s3_params():
             config.read(config_file)
             policy = config.get('aws', 's3-bucket-policy')
 
-
     return BucketInfo(bucket=bucket, policy=policy)
 
 

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -24,7 +24,7 @@ __all__ = [
     "wait_for_compute_environment", "wait_for_job_queue",
     "get_region", "set_region",
     "get_ecr_repo", "set_ecr_repo",
-    "get_s3_bucket", "set_s3_bucket", "get_s3_policy_name",
+    "get_s3_params", "set_s3_params",
     "get_profile", "set_profile", "list_profiles",
 ]
 
@@ -102,45 +102,70 @@ def set_ecr_repo(repo):
             clients['ecr'].create_repository(repositoryName=repo)
 
 
-def get_s3_bucket():
-    """Get the cloudknot S3 bucket
+def get_s3_params():
+    """Get the cloudknot S3 bucket and corresponding access policy
 
-    First, check the cloudknot config file for the bucket option.
-    If that fails, check for the CLOUDKNOT_S3_BUCKET environment variable.
-    If that fails, use 'cloudknot-' + getpass.getuser().lower() + '-' + uuid4()
+    For the bucket name, first check the cloudknot config file for the bucket
+    option. If that fails, check for the CLOUDKNOT_S3_BUCKET environment
+    variable. If that fails, use
+    'cloudknot-' + getpass.getuser().lower() + '-' + uuid4()
+
+    For the policy name, first check the cloudknot config file. If that fails,
+    use 'cloudknot-bucket-access-' + str(uuid.uuid4())
 
     Returns
     -------
-    bucket : string
-        Cloudknot S3 bucket name
+    bucket : NamedTuple
+        A named tuple with Cloudknot S3 bucket and policy fields
     """
     config_file = get_config_file()
     config = configparser.ConfigParser()
 
+    BucketInfo = namedtuple('BucketInfo', ['bucket', 'policy', ])
+
     with rlock:
         config.read(config_file)
+
+        option = 's3-bucket-policy'
+        if config.has_section('aws') and config.has_option('aws', option):
+            # Get policy name from the config file
+            policy = config.get('aws', option)
+        else:
+            # or set policy to None to create it in the call to
+            # set_s3_params()
+            policy = None
 
         option = 's3-bucket'
         if config.has_section('aws') and config.has_option('aws', option):
             bucket = config.get('aws', option)
         else:
-            # Set `bucket`, the fallback bucket in case the cloudknot
-            # bucket environment variable is not set
             try:
-                # Get the region from an environment variable
+                # Get the bucket name from an environment variable
                 bucket = os.environ['CLOUDKNOT_S3_BUCKET']
             except KeyError:
+                # Use the fallback bucket b/c the cloudknot
+                # bucket environment variable is not set
                 bucket = ('cloudknot-' + getpass.getuser().lower()
                           + '-' + str(uuid.uuid4()))
 
-        # Use set_s3_bucket to check for name availability
+            if policy is not None:
+                # In this case, the bucket name is new, but the policy is not.
+                # Update the policy to reflect the new bucket name.
+                update_s3_policy(policy=policy, bucket=bucket)
+
+        # Use set_s3_params to check for name availability
         # and write to config file
-        set_s3_bucket(bucket)
+        set_s3_params(bucket=bucket, policy=policy)
 
-    return bucket
+        if policy is None:
+            config.read(config_file)
+            policy = config.get('aws', 's3-bucket-policy')
 
 
-def set_s3_bucket(bucket):
+    return BucketInfo(bucket=bucket, policy=policy)
+
+
+def set_s3_params(bucket, policy=None):
     """Set the cloudknot S3 bucket
 
     Set bucket by modifying the cloudknot config file
@@ -149,23 +174,26 @@ def set_s3_bucket(bucket):
     ----------
     bucket : string
         Cloudknot S3 bucket name
+    policy : string
+        Cloudknot S3 bucket access policy name
+        Default: None means that cloudknot will create a new policy
     """
     # Update the config file
     config_file = get_config_file()
     config = configparser.ConfigParser()
 
-    def test_bucket_put_get(bucket):
+    def test_bucket_put_get(bucket_):
         key = 'cloudnot-test-permissions-key'
         try:
-            clients['s3'].put_object(Bucket=bucket, Body=b'test', Key=key)
-            clients['s3'].get_object(Bucket=bucket, Key=key)
+            clients['s3'].put_object(Bucket=bucket_, Body=b'test', Key=key)
+            clients['s3'].get_object(Bucket=bucket_, Key=key)
         except clients['s3'].exceptions.ClientError:
             raise ValueError('The requested bucket name already exists '
                              'and you do not have permission to put or '
                              'get objects in it.')
 
         try:
-            clients['s3'].delete_object(Bucket=bucket, Key=key)
+            clients['s3'].delete_object(Bucket=bucket_, Key=key)
         except Exception:
             pass
 
@@ -176,8 +204,6 @@ def set_s3_bucket(bucket):
             config.add_section('aws')
 
         config.set('aws', 's3-bucket', bucket)
-        with open(config_file, 'w') as f:
-            config.write(f)
 
         # Create the bucket
         try:
@@ -206,11 +232,30 @@ def set_s3_bucket(bucket):
                 # Pass exception to user
                 raise e
 
-        # Update the s3_policy with new bucket name
-        update_s3_policy(bucket)
+        if policy is None:
+            policy = 'cloudknot-bucket-access-' + str(uuid.uuid4())
+
+        try:
+            # Create the policy
+            s3_policy_doc = bucket_policy_document(bucket)
+
+            clients['iam'].create_policy(
+                PolicyName=policy,
+                Path='/cloudknot/',
+                PolicyDocument=json.dumps(s3_policy_doc),
+                Description='Grants access to S3 bucket {0:s}'
+                            ''.format(bucket)
+            )
+        except clients['iam'].exceptions.EntityAlreadyExistsException:
+            # Policy already exists, do nothing
+            pass
+
+        config.set('aws', 's3-bucket-policy', policy)
+        with open(config_file, 'w') as f:
+            config.write(f)
 
 
-def get_bucket_policy(bucket):
+def bucket_policy_document(bucket):
     """Return the policy document to access an S3 bucket
 
     Parameters
@@ -220,11 +265,11 @@ def get_bucket_policy(bucket):
 
     Returns
     -------
-    s3_policy: dict
+    s3_policy_doc: dict
         A dictionary containing the AWS policy document
     """
     # Add policy statements to access to cloudknot S3 bucket
-    s3_policy = {
+    s3_policy_doc = {
         "Version": "2012-10-17",
         "Statement": [
             {
@@ -240,71 +285,23 @@ def get_bucket_policy(bucket):
         ]
     }
 
-    return s3_policy
+    return s3_policy_doc
 
 
-def get_s3_policy_name(bucket):
-    """Get the policy that grants access to the cloudknot S3 bucket
-
-    First, check the cloudknot config file for the bucket-policy option.
-    If that fails, use 'cloudknot-bucket-access-' + uuid4()
-
-    Returns
-    -------
-    policy : string
-        Cloudknot S3 bucket access policy name
-    """
-    config_file = get_config_file()
-    config = configparser.ConfigParser()
-
-    with rlock:
-        config.read(config_file)
-
-        option = 's3-bucket-policy'
-        if config.has_section('aws') and config.has_option('aws', option):
-            # Get policy name from the config file
-            policy = config.get('aws', option)
-        else:
-            # or create new one if it doesn't exist
-            policy = 'cloudknot-bucket-access-' + str(uuid.uuid4())
-
-            if not config.has_section('aws'):
-                config.add_section('aws')
-
-            config.set('aws', option, policy)
-            with open(config_file, 'w') as f:
-                config.write(f)
-
-        s3_policy = get_bucket_policy(bucket)
-
-        try:
-            # Create the policy
-            clients['iam'].create_policy(
-                PolicyName=policy,
-                Path='/cloudknot/',
-                PolicyDocument=json.dumps(s3_policy),
-                Description='Grants access to S3 bucket {0:s}'.format(bucket)
-            )
-        except clients['iam'].exceptions.EntityAlreadyExistsException:
-            # Policy already exists, do nothing
-            pass
-
-    return policy
-
-
-def update_s3_policy(bucket):
+def update_s3_policy(policy, bucket):
     """Update the cloudknot S3 access policy with new bucket name
 
     Parameters
     ----------
+    policy: string
+        Amazon S3 bucket access policy name
+
     bucket: string
         Amazon S3 bucket name
     """
-    s3_policy = get_bucket_policy(bucket)
-    policy = get_s3_policy_name(bucket)
+    s3_policy_doc = bucket_policy_document(bucket)
 
-    # After calling get_s3_policy_name(), the policy already exists
-    # Get the ARN
+    # Get the ARN of the policy
     response = clients['iam'].list_policies(
         Scope='Local',
         PathPrefix='/cloudknot/'
@@ -320,7 +317,7 @@ def update_s3_policy(bucket):
             # Update the policy
             clients['iam'].create_policy_version(
                 PolicyArn=arn,
-                PolicyDocument=json.dumps(s3_policy),
+                PolicyDocument=json.dumps(s3_policy_doc),
                 SetAsDefault=True
             )
         except clients['iam'].exceptions.LimitExceededException:
@@ -343,7 +340,7 @@ def update_s3_policy(bucket):
             # Update the policy not that there's room for another version
             clients['iam'].create_policy_version(
                 PolicyArn=arn,
-                PolicyDocument=json.dumps(s3_policy),
+                PolicyDocument=json.dumps(s3_policy_doc),
                 SetAsDefault=True
             )
 

--- a/cloudknot/aws/batch.py
+++ b/cloudknot/aws/batch.py
@@ -15,7 +15,7 @@ from .base_classes import NamedObject, ObjectWithArn, \
     ResourceExistsException, ResourceDoesNotExistException, \
     ResourceClobberedException, CannotDeleteResourceException, \
     BatchJobFailedError, CKTimeoutError, \
-    wait_for_job_queue, get_s3_bucket
+    wait_for_job_queue, get_s3_params
 from .ec2 import Vpc, SecurityGroup
 from .ecr import DockerRepo
 from .iam import IamRole
@@ -165,7 +165,7 @@ class JobDefinition(ObjectWithUsernameAndMemory):
                     'or a string'
                 )
             self._docker_image = docker_image
-            self._output_bucket = get_s3_bucket()
+            self._output_bucket = get_s3_params().bucket
 
             # Validate vcpus input
             if vcpus:

--- a/cloudknot/aws/iam.py
+++ b/cloudknot/aws/iam.py
@@ -7,8 +7,7 @@ import six
 import tenacity
 from collections import namedtuple
 
-from .base_classes import ObjectWithArn, clients, \
-    get_s3_bucket, get_s3_policy_name, \
+from .base_classes import ObjectWithArn, clients, get_s3_params, \
     ResourceExistsException, ResourceDoesNotExistException, \
     ResourceClobberedException, CannotDeleteResourceException
 
@@ -143,9 +142,9 @@ class IamRole(ObjectWithArn):
                 )
 
             # Add the cloudknot s3 policy if not already in input_policies
-            bucket = get_s3_bucket()
+            s3_params = get_s3_params()
             self._policies = tuple(
-                input_policies | {get_s3_policy_name(bucket)}
+                input_policies | {s3_params.policy}
             )
 
             if not isinstance(add_instance_profile, bool):

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -48,11 +48,12 @@ def get_testing_name():
 
 @pytest.fixture(scope='module')
 def bucket_cleanup():
-    ck.set_s3_bucket('cloudknot-travis-build-45814031-351c-'
-                     '4b27-9a40-672c971f7e83')
+    ck.set_s3_params(bucket='cloudknot-travis-build-45814031-351c-'
+                            '4b27-9a40-672c971f7e83')
     yield None
-    bucket = ck.get_s3_bucket()
-    bucket_policy = ck.aws.base_classes.get_s3_policy_name(bucket)
+    s3_params = ck.get_s3_params()
+    bucket = s3_params.bucket
+    bucket_policy = s3_params.policy
 
     s3 = ck.aws.clients['s3']
     s3.delete_bucket(Bucket=bucket)
@@ -605,9 +606,9 @@ def test_IamRole(bucket_cleanup):
             assert role.description == d
             assert role.service == s + '.amazonaws.com'
             p = (p,) if isinstance(p, six.string_types) else tuple(p)
-            bucket = ck.get_s3_bucket()
+            s3_policy = ck.get_s3_params().policy
             assert set(role.policies) == (
-                set(p) | {ck.aws.base_classes.get_s3_policy_name(bucket)}
+                set(p) | {s3_policy}
             )
             if i:
                 assert role.instance_profile_arn

--- a/cloudknot/tests/test_cloudknot_dockerimage.py
+++ b/cloudknot/tests/test_cloudknot_dockerimage.py
@@ -24,11 +24,12 @@ def get_testing_name():
 
 @pytest.fixture(scope='module')
 def bucket_cleanup():
-    ck.set_s3_bucket('cloudknot-travis-build-45814031-351c-'
-                     '4b27-9a40-672c971f7e83')
+    ck.set_s3_params(bucket='cloudknot-travis-build-45814031-351c-'
+                            '4b27-9a40-672c971f7e83')
     yield None
-    bucket = ck.get_s3_bucket()
-    bucket_policy = ck.aws.base_classes.get_s3_policy_name(bucket)
+    s3_params = ck.get_s3_params()
+    bucket = s3_params.bucket
+    bucket_policy = s3_params.policy
 
     s3 = ck.aws.clients['s3']
     s3.delete_bucket(Bucket=bucket)

--- a/doc/api/aws.rst
+++ b/doc/api/aws.rst
@@ -32,8 +32,8 @@ Functions
    cloudknot.aws.set_profile
    cloudknot.aws.list_profiles
    cloudknot.aws.refresh_clients
-   cloudknot.aws.get_s3_bucket
-   cloudknot.aws.set_s3_bucket
+   cloudknot.aws.get_s3_params
+   cloudknot.aws.set_s3_params
 
 Clients
 -------

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -111,8 +111,8 @@ user. See, for example, :func:`cloudknot.Knot.map`,
 :func:`cloudknot.BatchJob.result <cloudknot.aws.BatchJob.result>`. Under
 the hood, these methods pass results through an Amazon S3 bucket. You can get
 and set the name of this S3 bucket using
-:func:`cloudknot.get_s3_bucket <cloudknot.aws.get_s3_bucket>` and
-:func:`cloudknot.set_s3_bucket <cloudknot.aws.set_s3_bucket>`.
+:func:`cloudknot.get_s3_params <cloudknot.aws.get_s3_params>` and
+:func:`cloudknot.set_s3_params <cloudknot.aws.set_s3_params>`.
 
 
 AWS resource limitations


### PR DESCRIPTION
Addresses #116 

If s3 bucket already exists, check put_object and get_object permissions first before throwing error.

WIP because `get_bucket()` and `set_bucket()` have been fixed but the bucket permissions steps still need to be fixed

- [x] rename `get_bucket_policy()` to `write_bucket_policy_document()` to disambiguate from retrieving the bucket policy name from config
- [x] rename `get_s3_policy_name()` to `get_s3_policy()` and remove the `create_policy` call from it. It should only retrieve info from config, just like `get_region()` or `get_s3_bucket()` do.
- [x] write a `set_s3_policy()` function to set the s3 policy and create it if it doesn't exist.
- [x] Update all the calls to these functions found elsewhere in cloudknot.