### PR TITLE
Fix circular dependency in cloudknot configure

### DIFF
--- a/cloudknot/__init__.py
+++ b/cloudknot/__init__.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-import configparser
 import errno
-import inspect
 import logging
 import os
-import re
 import subprocess
 
 from . import aws  # noqa
@@ -30,33 +27,6 @@ except subprocess.CalledProcessError:
         "installed, make sure that the Docker daemon is running before using "
         "cloudknot."
     )
-
-try:
-    context = inspect.stack()[-1].code_context
-except AttributeError:
-    context = inspect.stack()[-1][-2]
-
-pattern = re.compile(
-    'load_entry_point\(\'.*\', \'console_scripts\', \'cloudknot\'\)'
-)
-
-imported_from_config = context is not None and pattern.search(context[0])
-
-if not imported_from_config:
-    config_file = config.get_config_file()
-    conf = configparser.ConfigParser()
-    conf.read(config_file)
-
-    if not (conf.has_section('aws')
-            and conf.has_option('aws', 'configured')
-            and conf.get('aws', 'configured') == 'True'):
-        raise ImportError(
-            "It looks like you haven't run `cloudknot configure` to set up "
-            "your cloudknot environment. Or perhaps you did that but you have "
-            "since deleted your cloudknot configuration file. Please run "
-            "`cloudknot configure` before using cloudknot. "
-            "config_file = {cf:s}".format(cf=config_file)
-        )
 
 module_logger = logging.getLogger(__name__)
 

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -19,6 +19,7 @@ __all__ = [
     "ResourceExistsException", "CannotDeleteResourceException",
     "CannotCreateResourceException", "RegionException", "ProfileException",
     "BatchJobFailedError", "CKTimeoutError",
+    "CloudknotInputError", "CloudknotConfigurationError",
     "NamedObject", "ObjectWithArn", "ObjectWithUsernameAndMemory",
     "clients", "refresh_clients",
     "wait_for_compute_environment", "wait_for_job_queue",
@@ -157,7 +158,7 @@ def get_s3_params():
         if config.has_section('aws') and config.has_option('aws', option):
             sse = config.get('aws', option)
             if sse not in ['AES256', 'aws:kms', 'None']:
-                raise ValueError(
+                raise CloudknotInputError(
                     'The server-side encryption option "sse" must must be '
                     'one of ["AES256", "aws:kms", "None"]'
                 )
@@ -196,8 +197,8 @@ def set_s3_params(bucket, policy=None, sse=None):
         Default: None
     """
     if sse is not None and sse not in ['AES256', 'aws:kms']:
-        raise ValueError('The server-side encryption option "sse" '
-                         'must be one of ["AES256", "aws:kms"]')
+        raise CloudknotInputError('The server-side encryption option "sse" '
+                                  'must be one of ["AES256", "aws:kms"]')
 
     # Update the config file
     config_file = get_config_file()
@@ -214,9 +215,9 @@ def set_s3_params(bucket, policy=None, sse=None):
 
             clients['s3'].get_object(Bucket=bucket_, Key=key)
         except clients['s3'].exceptions.ClientError:
-            raise ValueError('The requested bucket name already exists '
-                             'and you do not have permission to put or '
-                             'get objects in it.')
+            raise CloudknotInputError('The requested bucket name already '
+                                      'exists and you do not have permission '
+                                      'to put or get objects in it.')
 
         try:
             clients['s3'].delete_object(Bucket=bucket_, Key=key)
@@ -444,7 +445,7 @@ def set_region(region='us-east-1'):
     region_names = [d['RegionName'] for d in response.get('Regions')]
 
     if region not in region_names:
-        raise ValueError('`region` must be in {regions!s}'.format(
+        raise CloudknotInputError('`region` must be in {regions!s}'.format(
             regions=region_names
         ))
 
@@ -598,7 +599,7 @@ def set_profile(profile_name):
     profile_info = list_profiles()
 
     if profile_name not in profile_info.profile_names:
-        raise ValueError(
+        raise CloudknotInputError(
             'The profile you specified does not exist in either the AWS '
             'config file at {conf:s} or the AWS shared credentials file at '
             '{cred:s}.'.format(
@@ -872,7 +873,7 @@ class CloudknotConfigurationError(Exception):
 
 
 # noinspection PyPropertyAccess,PyAttributeOutsideInit
-class CloudknotValueError(Exception):
+class CloudknotInputError(Exception):
     """Error indicating an input argument has an invalid value"""
     def __init__(self, msg):
         """Initialize the Exception
@@ -1001,11 +1002,11 @@ class ObjectWithUsernameAndMemory(ObjectWithArn):
         try:
             mem = int(memory)
             if mem < 1:
-                raise ValueError('memory must be positive')
+                raise CloudknotInputError('memory must be positive')
             else:
                 self._memory = mem
         except ValueError:
-            raise ValueError('memory must be an integer')
+            raise CloudknotInputError('memory must be an integer')
 
         self._username = str(username)
 

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -852,6 +852,40 @@ class BatchJobFailedError(Exception):
 
 
 # noinspection PyPropertyAccess,PyAttributeOutsideInit
+class CloudknotConfigurationError(Exception):
+    """Error indicating an cloudknot has not been properly configured"""
+    def __init__(self, config_file):
+        """Initialize the Exception
+
+        Parameters
+        ----------
+        config_file : string
+            The path to the cloudknot config file
+        """
+        super(CloudknotConfigurationError, self).__init__(
+            "It looks like you haven't run `cloudknot configure` to set up "
+            "your cloudknot environment. Or perhaps you did that but you have "
+            "since deleted your cloudknot configuration file. Please run "
+            "`cloudknot configure` before using cloudknot. "
+        )
+        self.config_file = config_file
+
+
+# noinspection PyPropertyAccess,PyAttributeOutsideInit
+class CloudknotValueError(Exception):
+    """Error indicating an input argument has an invalid value"""
+    def __init__(self, msg):
+        """Initialize the Exception
+
+        Parameters
+        ----------
+        msg : string
+            The error message
+        """
+        super(CloudknotConfigurationError, self).__init__(msg)
+
+
+# noinspection PyPropertyAccess,PyAttributeOutsideInit
 class NamedObject(object):
     """Base class for building objects with name property"""
     def __init__(self, name):
@@ -862,6 +896,16 @@ class NamedObject(object):
         name : string
             Name of the object
         """
+        config_file = get_config_file()
+        conf = configparser.ConfigParser()
+        with rlock:
+            conf.read(config_file)
+
+            if not (conf.has_section('aws')
+                    and conf.has_option('aws', 'configured')
+                    and conf.get('aws', 'configured') == 'True'):
+                raise CloudknotConfigurationError(config_file)
+
         self._name = str(name)
         self._clobbered = False
         self._region = get_region()

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -883,7 +883,7 @@ class CloudknotInputError(Exception):
         msg : string
             The error message
         """
-        super(CloudknotConfigurationError, self).__init__(msg)
+        super(CloudknotInputError, self).__init__(msg)
 
 
 # noinspection PyPropertyAccess,PyAttributeOutsideInit

--- a/cloudknot/aws/iam.py
+++ b/cloudknot/aws/iam.py
@@ -9,7 +9,8 @@ from collections import namedtuple
 
 from .base_classes import ObjectWithArn, clients, get_s3_params, \
     ResourceExistsException, ResourceDoesNotExistException, \
-    ResourceClobberedException, CannotDeleteResourceException
+    ResourceClobberedException, CannotDeleteResourceException, \
+    CloudknotInputError
 
 __all__ = ["IamRole"]
 
@@ -92,7 +93,7 @@ class IamRole(ObjectWithArn):
                 self._service = service + '.amazonaws.com'
             else:
                 msg = 'service must be in ' + str(self._allowed_services)
-                raise ValueError(msg)
+                raise CloudknotInputError(msg)
 
             # "Version": "2012-10-17",
             role_policy = {
@@ -114,11 +115,11 @@ class IamRole(ObjectWithArn):
                     if all(isinstance(x, six.string_types) for x in policies):
                         input_policies = set(list(policies))
                     else:
-                        raise ValueError('policies must be a string or a '
-                                         'sequence of strings.')
+                        raise CloudknotInputError('policies must be a string '
+                                                  'or a sequence of strings.')
                 except TypeError:
-                    raise ValueError('policies must be a string or a '
-                                     'sequence of strings')
+                    raise CloudknotInputError('policies must be a string or a '
+                                              'sequence of strings')
 
             # Get all AWS policies
             response = clients['iam'].list_policies()
@@ -136,7 +137,7 @@ class IamRole(ObjectWithArn):
             # If input policies are not a subset of aws_policies, throw error
             if not (input_policies < set(aws_policies)):
                 bad_policies = input_policies - set(aws_policies)
-                raise ValueError(
+                raise CloudknotInputError(
                     'Could not find the policies {bad_policies!s} on '
                     'AWS.'.format(bad_policies=bad_policies)
                 )
@@ -148,7 +149,8 @@ class IamRole(ObjectWithArn):
             )
 
             if not isinstance(add_instance_profile, bool):
-                raise ValueError('add_instance_profile is a boolean input')
+                raise CloudknotInputError('add_instance_profile is a '
+                                          'boolean input')
 
             self._arn = self._create(add_instance_profile=add_instance_profile)
 

--- a/cloudknot/cli.py
+++ b/cloudknot/cli.py
@@ -15,8 +15,10 @@ Help:
   https://github.com/richford/cloudknot
 """
 
-from inspect import getmembers, isclass
+from __future__ import absolute_import, division, print_function
+
 from docopt import docopt
+from inspect import getmembers, isclass
 
 from . import __version__ as VERSION
 

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -87,23 +87,27 @@ class Pars(aws.NamedObject):
         """
         # Validate name input
         if not isinstance(name, six.string_types):
-            raise ValueError('PARS name must be a string. You passed a '
-                             '{t!s}'.format(t=type(name)))
+            raise aws.CloudknotInputError(
+                'PARS name must be a string. You passed a '
+                '{t!s}'.format(t=type(name))
+            )
 
         super(Pars, self).__init__(name=name)
 
         # Validate vpc_name input
         if vpc_name:
             if not isinstance(vpc_name, six.string_types):
-                raise ValueError('if provided, vpc_name must be a string.')
+                raise aws.CloudknotInputError('if provided, vpc_name must be '
+                                              'a string.')
         else:
             vpc_name = name + '-cloudknot-vpc'
 
         # Validate security_group_name input
         if security_group_name:
             if not isinstance(security_group_name, six.string_types):
-                raise ValueError('if provided, security_group_name must be '
-                                 'a string.')
+                raise aws.CloudknotInputError(
+                    'if provided, security_group_name must be a string.'
+                )
         else:
             security_group_name = name + '-cloudknot-security-group'
 
@@ -121,9 +125,10 @@ class Pars(aws.NamedObject):
             # Pars exists, check that user did not provide any resource names
             if any([batch_service_role_name, ecs_instance_role_name,
                     spot_fleet_role_name, vpc_id, security_group_id]):
-                raise ValueError('You provided resources for a pars that '
-                                 'already exists in configuration file '
-                                 '{fn:s}.'.format(fn=get_config_file()))
+                raise aws.CloudknotInputError(
+                    'You provided resources for a pars that already exists in '
+                    'configuration file {fn:s}.'.format(fn=get_config_file())
+                )
 
             mod_logger.info('Found PARS {name:s} in config'.format(name=name))
 
@@ -275,8 +280,9 @@ class Pars(aws.NamedObject):
                 # Validate role name input
                 if role_name:
                     if not isinstance(role_name, six.string_types):
-                        raise ValueError('if provided, role names must '
-                                         'be strings.')
+                        raise aws.CloudknotInputError(
+                            'if provided, role names must be strings.'
+                        )
                 else:
                     role_name = (
                         name + '-cloudknot-' + fallback_suffix
@@ -295,13 +301,14 @@ class Pars(aws.NamedObject):
 
             # Validate vpc_id input
             if vpc_id and not isinstance(vpc_id, six.string_types):
-                raise ValueError('if provided, vpc_id must be a string')
+                raise aws.CloudknotInputError('if provided, vpc_id must be a '
+                                              'string')
 
             # Validate security_group_id input
             if security_group_id and not isinstance(security_group_id,
                                                     six.string_types):
-                raise ValueError('if provided, security_group_id '
-                                 'must be a string')
+                raise aws.CloudknotInputError('if provided, security_group_id '
+                                              'must be a string')
 
             def set_role(pars_name, role_name, service, policies,
                          add_instance_profile):
@@ -500,7 +507,8 @@ class Pars(aws.NamedObject):
 
             # Verify input
             if not isinstance(new_role, aws.IamRole):
-                raise ValueError('new role must be an instance of IamRole')
+                raise aws.CloudknotInputError('new role must be an instance '
+                                              'of IamRole')
 
             old_role = getattr(self, attr)
 
@@ -582,7 +590,7 @@ class Pars(aws.NamedObject):
             )
 
         if not isinstance(v, aws.Vpc):
-            raise ValueError('new vpc must be an instance of Vpc')
+            raise aws.CloudknotInputError('new vpc must be an instance of Vpc')
 
         if v.region != self._vpc.region:
             raise aws.RegionException(v.region)
@@ -656,8 +664,8 @@ class Pars(aws.NamedObject):
             )
 
         if not isinstance(sg, aws.SecurityGroup):
-            raise ValueError('new security group must be an instance of '
-                             'SecurityGroup')
+            raise aws.CloudknotInputError('new security group must be an '
+                                          'instance of SecurityGroup')
 
         if sg.region != self._security_group.region:
             raise aws.RegionException(sg.region)
@@ -869,8 +877,10 @@ class Knot(aws.NamedObject):
         """
         # Validate name input
         if not isinstance(name, six.string_types):
-            raise ValueError('Knot name must be a string. You passed a '
-                             '{t!s}'.format(t=type(name)))
+            raise aws.CloudknotInputError(
+                'Knot name must be a string. You passed a '
+                '{t!s}'.format(t=type(name))
+            )
 
         super(Knot, self).__init__(name=name)
         self._knot_name = 'knot ' + name
@@ -968,11 +978,12 @@ class Knot(aws.NamedObject):
                 else name + '-cloudknot-job-queue'
 
             if pars and not isinstance(pars, Pars):
-                raise ValueError('if provided, pars must be a Pars instance.')
+                raise aws.CloudknotInputError('if provided, pars must be a '
+                                              'Pars instance.')
 
             if docker_image and any([func, image_script_path, image_work_dir,
                                      image_github_installs]):
-                raise ValueError(
+                raise aws.CloudknotInputError(
                     'you gave redundant, possibly conflicting input: '
                     '`docker_image` and one of [`func`, '
                     '`image_script_path`, `image_work_dir`]'
@@ -980,8 +991,9 @@ class Knot(aws.NamedObject):
 
             if docker_image and not isinstance(docker_image,
                                                dockerimage.DockerImage):
-                raise ValueError('docker_image must be a cloudknot '
-                                 'DockerImage instance.')
+                raise aws.CloudknotInputError(
+                    'docker_image must be a cloudknot DockerImage instance.'
+                )
 
             def set_pars(knot_name, input_pars, pars_policies):
                 # Validate and set the PARS
@@ -1118,7 +1130,7 @@ class Knot(aws.NamedObject):
                     }
 
                     if not all(matches.values()):
-                        raise ValueError(
+                        raise aws.CloudknotInputError(
                             'The requested job definition already exists but '
                             'does not match the input parameters. '
                             '{matches!s}'.format(matches=matches)
@@ -1220,7 +1232,7 @@ class Knot(aws.NamedObject):
                     }
 
                     if not all(matches.values()):
-                        raise ValueError(
+                        raise aws.CloudknotInputError(
                             'The requested compute environment already exists '
                             'but does not match the input parameters. '
                             '{matches!s}.'.format(matches=matches)
@@ -1272,7 +1284,7 @@ class Knot(aws.NamedObject):
                     }
 
                     if not all(matches.values()):
-                        raise ValueError(
+                        raise aws.CloudknotInputError(
                             'The requested job queue already exists '
                             'but does not match the input parameters. '
                             '{matches!s}'.format(matches=matches)
@@ -1322,7 +1334,7 @@ class Knot(aws.NamedObject):
             try:
                 self._compute_environment, ce_cleanup = \
                     futures['compute-environment'].result()
-            except ValueError as e:
+            except aws.CloudknotInputError as e:
                 if pars_cleanup:
                     self.pars.clobber()
                 raise e
@@ -1335,7 +1347,7 @@ class Knot(aws.NamedObject):
 
             try:
                 self._job_queue, jq_cleanup = futures['job-queue'].result()
-            except ValueError as e:
+            except aws.CloudknotInputError as e:
                 if ce_cleanup:
                     self.compute_environment.clobber()
                 if pars_cleanup:
@@ -1356,7 +1368,7 @@ class Knot(aws.NamedObject):
             try:
                 self._job_definition, jd_cleanup = \
                     futures['job-definition'].result()
-            except ValueError as e:
+            except aws.CloudknotInputError as e:
                 if jq_cleanup:
                     self.job_queue.clobber()
                 if ce_cleanup:
@@ -1379,9 +1391,10 @@ class Knot(aws.NamedObject):
                 if pars_cleanup:
                     self.pars.clobber()
 
-                raise ValueError("The username for this knot's job definition "
-                                 "does not match the username for this knot's "
-                                 "Docker image.")
+                raise aws.CloudknotInputError(
+                    "The username for this knot's job definition does not "
+                    "match the username for this knot's Docker image."
+                )
 
             executor.shutdown()
 
@@ -1512,13 +1525,14 @@ class Knot(aws.NamedObject):
 
         # env_vars should be a sequence of sequences of dicts
         if env_vars and not all(isinstance(s, dict) for s in env_vars):
-            raise ValueError('env_vars must be a sequence of dicts')
+            raise aws.CloudknotInputError('env_vars must be a sequence of '
+                                          'dicts')
 
         # and each dict should have only 'name' and 'value' keys
         if env_vars and not all(set(d.keys()) == {'name', 'value'}
                                 for d in env_vars):
-            raise ValueError('each dict in env_vars must have '
-                             'keys "name" and "value"')
+            raise aws.CloudknotInputError('each dict in env_vars must have '
+                                          'keys "name" and "value"')
 
         these_jobs = []
 

--- a/cloudknot/commands/configure.py
+++ b/cloudknot/commands/configure.py
@@ -107,6 +107,8 @@ class Configure(Base):
             else:
                 values[config_name] = default_value
 
+        add_resource('aws', 'configured', 'True')
+
         print('\nCloudknot will now pull the base python docker image to your '
               'local machine and push the same docker image to your cloudknot '
               'repository on AWS ECR.')
@@ -114,7 +116,5 @@ class Configure(Base):
         pull_and_push_base_images(region=values['region'],
                                   profile=values['profile'],
                                   ecr_repo=values['ecr_repo'])
-
-        add_resource('aws', 'configured', 'True')
 
         print('All done.\n')

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -77,14 +77,17 @@ def bucket_cleanup():
     versions = [v for v in response.get('Versions')
                 if not v['IsDefaultVersion']]
 
-    # Get the oldest version and delete it
+    # Delete the non-default versions
     for v in versions:
         iam.delete_policy_version(
             PolicyArn=arn,
             VersionId=v['VersionId']
         )
 
-    iam.delete_policy(PolicyArn=arn)
+    try:
+        iam.delete_policy(PolicyArn=arn)
+    except Exception:
+        pass
 
 
 @pytest.fixture(scope='module')
@@ -1985,7 +1988,7 @@ def test_ComputeEnvironment(pars):
                 name=get_testing_name()
             )
 
-        # ck.aws.CloudknotInputError for 'SPOT' resource with no spot_fleet_role
+        # CloudknotInputError for 'SPOT' resource with no spot_fleet_role
         with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
@@ -2342,7 +2345,7 @@ def test_JobQueue(pars):
 
         assert name in config.options(jq_section_name)
 
-        # Assert ck.aws.CloudknotInputError on invalid status in get_jobs() method
+        # Assert CloudknotInputError on invalid status in get_jobs() method
         with pytest.raises(ck.aws.CloudknotInputError):
             jq.get_jobs(status='INVALID')
 

--- a/cloudknot/tests/test_aws.py
+++ b/cloudknot/tests/test_aws.py
@@ -267,7 +267,7 @@ def test_get_region(bucket_cleanup):
 
 
 def test_set_region(bucket_cleanup):
-    with pytest.raises(ValueError):
+    with pytest.raises(ck.aws.CloudknotInputError):
         ck.set_region(region='not a valid region name')
 
     old_region = ck.get_region()
@@ -449,7 +449,7 @@ def test_set_profile(bucket_cleanup):
         cred_file = op.join(ref_dir, 'credentials_without_default')
         os.environ['AWS_SHARED_CREDENTIALS_FILE'] = cred_file
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.set_profile(profile_name='not_in_list_of_profiles')
 
         profile = 'name-5'
@@ -487,7 +487,7 @@ def test_set_profile(bucket_cleanup):
 
 def test_ObjectWithUsernameAndMemory(bucket_cleanup):
     for mem in [-42, 'not-an-int']:
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.base_classes.ObjectWithUsernameAndMemory(
                 name=get_testing_name(),
                 memory=mem
@@ -639,17 +639,17 @@ def test_IamRole(bucket_cleanup):
             assert n not in config.options(role_section_name)
 
         # Test for correct handling of incorrect input
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.IamRole(name='not-important', service='value-error')
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.IamRole(name='not-important', service='ec2', policies=455)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.IamRole(name='not-important', service='ec2',
                            policies=[455, 455])
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.IamRole(name='not-important', service='ec2',
                            policies='NotAnAWSPolicy')
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.IamRole(name='not-important', service='ec2',
                            add_instance_profile=455)
 
@@ -1093,20 +1093,20 @@ def test_Vpc(bucket_cleanup):
         vpc.clobber()
 
         # Test for correct handling of incorrect input
-        # Assert ValueError on no input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on no input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.Vpc()
 
-        # Assert ValueError on vpc_id and name input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on vpc_id and name input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.Vpc(vpc_id=get_testing_name(), name=get_testing_name())
 
-        # Assert ValueError on invalid ipv4_cidr
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid ipv4_cidr
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.Vpc(name=get_testing_name(), ipv4_cidr='not-valid')
 
-        # Assert ValueError on invalid instance tenancy
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid instance tenancy
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.Vpc(name=get_testing_name(), instance_tenancy='not-valid')
 
         # Assert ResourceDoesNotExistException on invalid vpc_id
@@ -1388,19 +1388,19 @@ def test_SecurityGroup(bucket_cleanup):
             assert sg.security_group_id not in config.options(sg_section_name)
 
         # Test for correct handling of incorrect input
-        # Assert ValueError on no input
-        with pytest.raises(ValueError) as e:
+        # Assert ck.aws.CloudknotInputError on no input
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.SecurityGroup()
 
-        # Assert ValueError on name and group_id input
-        with pytest.raises(ValueError) as e:
+        # Assert ck.aws.CloudknotInputError on name and group_id input
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.SecurityGroup(
                 security_group_id=get_testing_name(),
                 name=get_testing_name()
             )
 
-        # Assert ValueError on invalid vpc input
-        with pytest.raises(ValueError) as e:
+        # Assert ck.aws.CloudknotInputError on invalid vpc input
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.SecurityGroup(name=get_testing_name(), vpc=5)
 
         # Finally clean up the VPC that we used for testing
@@ -1636,39 +1636,39 @@ def test_JobDefinition(pars):
             assert jd.name not in config.options(jd_section_name)
 
         # Test for correct handling of incorrect input
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobDefinition()
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobDefinition(
                 arn=get_testing_name(),
                 name=get_testing_name()
             )
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobDefinition(
                 name=get_testing_name(),
                 job_role=5, docker_image='ubuntu'
             )
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobDefinition(
                 name=get_testing_name(),
                 job_role=pars.batch_service_role,
                 docker_image=5
             )
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobDefinition(
                 name=get_testing_name(),
                 job_role=pars.batch_service_role,
                 docker_image='ubuntu',
                 vcpus=-2
             )
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobDefinition(
                 name=get_testing_name(),
                 job_role=pars.batch_service_role,
                 docker_image='ubuntu',
                 retries=0
             )
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobDefinition(
                 name=get_testing_name(),
                 job_role=pars.batch_service_role,
@@ -1974,19 +1974,19 @@ def test_ComputeEnvironment(pars):
             assert ce.name not in config.options(ce_section_name)
 
         # Test for correct handling of incorrect input
-        # ValueError for neither arn or name
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for neither arn or name
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment()
 
         # Value Error for both arn and name
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 arn=get_testing_name(),
                 name=get_testing_name()
             )
 
-        # ValueError for 'SPOT' resource with no spot_fleet_role
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for 'SPOT' resource with no spot_fleet_role
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -1995,8 +1995,8 @@ def test_ComputeEnvironment(pars):
                 resource_type='SPOT', bid_percentage=50
             )
 
-        # ValueError for 'SPOT' resource with no bid_percentage
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for 'SPOT' resource with no bid_percentage
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2006,8 +2006,8 @@ def test_ComputeEnvironment(pars):
                 resource_type='SPOT'
             )
 
-        # ValueError for bad batch_service_role
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad batch_service_role
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.ecs_instance_role,
@@ -2015,8 +2015,8 @@ def test_ComputeEnvironment(pars):
                 security_group=pars.security_group
             )
 
-        # ValueError for bad instance_role
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad instance_role
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2024,8 +2024,8 @@ def test_ComputeEnvironment(pars):
                 security_group=pars.security_group
             )
 
-        # ValueError for bad vpc
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad vpc
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2034,8 +2034,8 @@ def test_ComputeEnvironment(pars):
                 security_group=pars.security_group
             )
 
-        # ValueError for bad security_group
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad security_group
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2044,8 +2044,8 @@ def test_ComputeEnvironment(pars):
                 security_group=pars.vpc
             )
 
-        # ValueError for bad spot_fleet_role
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad spot_fleet_role
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2055,9 +2055,9 @@ def test_ComputeEnvironment(pars):
                 spot_fleet_role=pars.batch_service_role
             )
 
-        # ValueError for bad instance_types
+        # ck.aws.CloudknotInputError for bad instance_types
         for instance_type in [[5, 4], 'bad-instance-type-string']:
-            with pytest.raises(ValueError) as e:
+            with pytest.raises(ck.aws.CloudknotInputError) as e:
                 ck.aws.ComputeEnvironment(
                     name=get_testing_name(),
                     batch_service_role=pars.batch_service_role,
@@ -2067,8 +2067,8 @@ def test_ComputeEnvironment(pars):
                     instance_types=instance_type
                 )
 
-        # ValueError for bad resource_type
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad resource_type
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2078,8 +2078,8 @@ def test_ComputeEnvironment(pars):
                 resource_type='BAD'
             )
 
-        # ValueError for bad min_vcpus
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad min_vcpus
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2089,8 +2089,8 @@ def test_ComputeEnvironment(pars):
                 min_vcpus=-42
             )
 
-        # ValueError for bad max_vcpus
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad max_vcpus
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2100,8 +2100,8 @@ def test_ComputeEnvironment(pars):
                 max_vcpus=-42
             )
 
-        # ValueError for bad desired_vcpus
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad desired_vcpus
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2111,8 +2111,8 @@ def test_ComputeEnvironment(pars):
                 desired_vcpus=-42
             )
 
-        # ValueError for bad image_id
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad image_id
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2122,8 +2122,8 @@ def test_ComputeEnvironment(pars):
                 image_id=42
             )
 
-        # ValueError for bad ec2_key_pair
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad ec2_key_pair
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2133,8 +2133,8 @@ def test_ComputeEnvironment(pars):
                 ec2_key_pair=-42
             )
 
-        # ValueError for bad ec2_key_pair
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for bad ec2_key_pair
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.ComputeEnvironment(
                 name=get_testing_name(),
                 batch_service_role=pars.batch_service_role,
@@ -2342,8 +2342,8 @@ def test_JobQueue(pars):
 
         assert name in config.options(jq_section_name)
 
-        # Assert ValueError on invalid status in get_jobs() method
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid status in get_jobs() method
+        with pytest.raises(ck.aws.CloudknotInputError):
             jq.get_jobs(status='INVALID')
 
         assert jq.get_jobs() == []
@@ -2454,16 +2454,16 @@ def test_JobQueue(pars):
         ce2.clobber()
 
         # Test for correct handling of incorrect input
-        # ValueError for neither arn or name
-        with pytest.raises(ValueError) as e:
+        # ck.aws.CloudknotInputError for neither arn or name
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobQueue()
 
         # Value Error for both arn and name
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobQueue(arn=get_testing_name(), name=get_testing_name())
 
         # Value Error for negative priority
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobQueue(
                 name=get_testing_name(),
                 compute_environments=ce,
@@ -2471,7 +2471,7 @@ def test_JobQueue(pars):
             )
 
         # Value Error for invalid compute environments
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ck.aws.CloudknotInputError) as e:
             ck.aws.JobQueue(
                 name=get_testing_name(),
                 compute_environments=[42, -42]
@@ -2681,27 +2681,27 @@ def test_BatchJob(pars):
             priority=1
         )
 
-        # Assert ValueError on insufficient input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on insufficient input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.BatchJob()
 
-        # Assert ValueError on over-specified input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on over-specified input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.BatchJob(
                 job_id=42,
                 name=get_testing_name()
             )
 
-        # Assert ValueError on invalid job_queue
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid job_queue
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.BatchJob(
                 name=get_testing_name(),
                 input=42,
                 job_queue=42
             )
 
-        # Assert ValueError on invalid job_definition
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid job_definition
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.BatchJob(
                 name=get_testing_name(),
                 input=42,
@@ -2709,8 +2709,8 @@ def test_BatchJob(pars):
                 job_definition=42
             )
 
-        # Assert ValueError on invalid environment variable
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid environment variable
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.aws.BatchJob(
                 name=get_testing_name(),
                 input=42,

--- a/cloudknot/tests/test_cloudknot_dockerimage.py
+++ b/cloudknot/tests/test_cloudknot_dockerimage.py
@@ -587,7 +587,7 @@ def test_Pars(bucket_cleanup):
         # Now re-instantiate so that the PARS loads from the config file
         # with resources that don't exist anymore
         # First, with specifying other resource names, to throw error
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=name, spot_fleet_role_name=get_testing_name())
 
         # And for real this time
@@ -647,7 +647,7 @@ def test_Pars(bucket_cleanup):
 
         # Test setting new batch service role
         # -----------------------------------
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             p.batch_service_role = 42
 
         role = ck.aws.IamRole(
@@ -669,7 +669,7 @@ def test_Pars(bucket_cleanup):
 
         # Test setting new ecs instance role
         # ----------------------------------
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             p.ecs_instance_role = 42
 
         role = ck.aws.IamRole(
@@ -692,7 +692,7 @@ def test_Pars(bucket_cleanup):
 
         # Test setting new spot fleet role
         # --------------------------------
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             p.spot_fleet_role = 42
 
         role = ck.aws.IamRole(
@@ -714,7 +714,7 @@ def test_Pars(bucket_cleanup):
 
         # Test setting new security group
         # --------------------------------
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             p.security_group = 42
 
         sg = ck.aws.SecurityGroup(name=get_testing_name(), vpc=p.vpc)
@@ -733,7 +733,7 @@ def test_Pars(bucket_cleanup):
 
         # Test setting new VPC
         # --------------------------------
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             p.vpc = 42
 
         vpc = ck.aws.Vpc(name=get_testing_name())
@@ -759,36 +759,36 @@ def test_Pars(bucket_cleanup):
 
         # Test Exceptions on invalid input
         # --------------------------------
-        # Assert ValueError on invalid name
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid name
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=42)
 
-        # Assert ValueError on invalid vpc_name
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid vpc_name
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=get_testing_name(), vpc_name=42)
 
-        # Assert ValueError on invalid vpc_id
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid vpc_id
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=get_testing_name(), vpc_id=42)
 
-        # Assert ValueError on invalid security_group_name
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid security_group_name
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=get_testing_name(), security_group_name=42)
 
-        # Assert ValueError on invalid security_group_id
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid security_group_id
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=get_testing_name(), security_group_id=42)
 
-        # Assert ValueError on invalid batch_service_role_name
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid batch_service_role_name
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=get_testing_name(), batch_service_role_name=42)
 
-        # Assert ValueError on invalid ecs_instance_role_name
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid ecs_instance_role_name
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=get_testing_name(), ecs_instance_role_name=42)
 
-        # Assert ValueError on invalid spot_fleet_role_name
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid spot_fleet_role_name
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.Pars(name=get_testing_name(), spot_fleet_role_name=42)
     except Exception as e:
         if p:
@@ -1037,36 +1037,36 @@ def test_DockerImage(cleanup_repos):
         # Test for exception handling of incorrect input
         # ----------------------------------------------
 
-        # Assert ValueError on no input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on no input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage()
 
-        # Assert ValueError on name plus other input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on name plus other input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(name=get_testing_name(), func=unit_testing_func)
 
-        # Assert ValueError on non-string name input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on non-string name input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(name=42)
 
-        # Assert ValueError on non-existent name input
+        # Assert ck.aws.CloudknotInputError on non-existent name input
         with pytest.raises(ck.aws.ResourceDoesNotExistException):
             ck.DockerImage(name=get_testing_name())
 
-        # Assert ValueError on redundant input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on redundant input
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(
                 func=unit_testing_func,
                 script_path=correct_script_path,
                 dir_name=os.getcwd()
             )
 
-        # Assert ValueError on invalid script path
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid script path
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(script_path=str(uuid.uuid4()), dir_name=os.getcwd())
 
-        # Assert ValueError on invalid dir name
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on invalid dir name
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(
                 script_path=correct_script_path,
                 dir_name=str(uuid.uuid4())
@@ -1075,15 +1075,15 @@ def test_DockerImage(cleanup_repos):
         correct_dir = op.join(
             data_path, 'docker_reqs_ref_data', py_dir, 'ref1'
         )
-        # Assert ValueError to prevent overwriting existing script
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError to prevent overwriting existing script
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(func=unit_testing_func, dir_name=correct_dir)
 
-        # Assert ValueError to prevent overwriting existing Dockerfile
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError to prevent overwriting existing Dockerfile
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(script_path=correct_script_path)
 
-        # Assert ValueError to prevent overwriting existing requirements.txt
+        # Assert ck.aws.CloudknotInputError to prevent overwriting existing requirements.txt
         # First, avoid the existing Dockerfile error by renaming the Dockerfile
         old_dockerfile = op.join(op.dirname(correct_script_path), 'Dockerfile')
 
@@ -1092,8 +1092,8 @@ def test_DockerImage(cleanup_repos):
         )
         os.rename(old_dockerfile, new_dockerfile)
 
-        # Assert the ValueError
-        with pytest.raises(ValueError):
+        # Assert the ck.aws.CloudknotInputError
+        with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(script_path=correct_script_path)
 
         # Clean up our mess by renaming to the old Dockerfile
@@ -1112,24 +1112,24 @@ def test_DockerImage(cleanup_repos):
 
         repo = ck.aws.DockerRepo(name=repo_name)
 
-        # Assert ValueError on push without args
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on push without args
+        with pytest.raises(ck.aws.CloudknotInputError):
             di.push()
 
-        # Assert ValueError on over-specified input
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on over-specified input
+        with pytest.raises(ck.aws.CloudknotInputError):
             di.push(repo="input doesn't matter here", repo_uri=str(repo_uri))
 
-        # Assert ValueError on push before build
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on push before build
+        with pytest.raises(ck.aws.CloudknotInputError):
             di.push(repo_uri=str(repo_uri))
 
-        # Assert ValueError on incorrect build args
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on incorrect build args
+        with pytest.raises(ck.aws.CloudknotInputError):
             di.build(tags=[42, -42])
 
-        # Assert ValueError on 'latest' in tags
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on 'latest' in tags
+        with pytest.raises(ck.aws.CloudknotInputError):
             di.build(tags=['testing', 'latest'])
 
         tags = ['testing', ['testing1', 'testing2']]
@@ -1153,12 +1153,12 @@ def test_DockerImage(cleanup_repos):
 
             assert repo_uri in di.repo_uri
 
-        # Assert ValueError on push with invalid repo
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on push with invalid repo
+        with pytest.raises(ck.aws.CloudknotInputError):
             di.push(repo=42)
 
-        # Assert ValueError on push with invalid repo_uri
-        with pytest.raises(ValueError):
+        # Assert ck.aws.CloudknotInputError on push with invalid repo_uri
+        with pytest.raises(ck.aws.CloudknotInputError):
             di.push(repo_uri=42)
 
         di.clobber()
@@ -1167,7 +1167,7 @@ def test_DockerImage(cleanup_repos):
         with pytest.raises(ck.aws.ResourceClobberedException):
             di.build(tags=['testing'])
 
-        # Assert ValueError on push with invalid repo_uri
+        # Assert ck.aws.CloudknotInputError on push with invalid repo_uri
         with pytest.raises(ck.aws.ResourceClobberedException):
             di.push(repo=repo)
     except Exception as e:
@@ -1329,7 +1329,7 @@ def test_Knot(cleanup_repos):
             priority=1
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             knot = ck.Knot(
                 name=get_testing_name(),
                 func=unit_testing_func,
@@ -1337,7 +1337,7 @@ def test_Knot(cleanup_repos):
                 job_def_vcpus=42
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             knot = ck.Knot(
                 name=get_testing_name(),
                 func=unit_testing_func,
@@ -1345,7 +1345,7 @@ def test_Knot(cleanup_repos):
                 desired_vcpus=42
             )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ck.aws.CloudknotInputError):
             knot = ck.Knot(
                 name=get_testing_name(),
                 func=unit_testing_func,
@@ -1368,10 +1368,10 @@ def test_Knot(cleanup_repos):
 
     # Test Exceptions on invalid input
     # --------------------------------
-    # Assert ValueError on invalid name
-    with pytest.raises(ValueError):
+    # Assert ck.aws.CloudknotInputError on invalid name
+    with pytest.raises(ck.aws.CloudknotInputError):
         ck.Knot(name=42)
 
-    # Assert ValueError on invalid pars input
-    with pytest.raises(ValueError):
+    # Assert ck.aws.CloudknotInputError on invalid pars input
+    with pytest.raises(ck.aws.CloudknotInputError):
         ck.Knot(func=unit_testing_func, pars=42)

--- a/cloudknot/tests/test_cloudknot_dockerimage.py
+++ b/cloudknot/tests/test_cloudknot_dockerimage.py
@@ -1075,15 +1075,16 @@ def test_DockerImage(cleanup_repos):
         correct_dir = op.join(
             data_path, 'docker_reqs_ref_data', py_dir, 'ref1'
         )
-        # Assert ck.aws.CloudknotInputError to prevent overwriting existing script
+        # Assert CloudknotInputError to prevent overwriting existing script
         with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(func=unit_testing_func, dir_name=correct_dir)
 
-        # Assert ck.aws.CloudknotInputError to prevent overwriting existing Dockerfile
+        # Assert CloudknotInputError to prevent overwriting existing Dockerfile
         with pytest.raises(ck.aws.CloudknotInputError):
             ck.DockerImage(script_path=correct_script_path)
 
-        # Assert ck.aws.CloudknotInputError to prevent overwriting existing requirements.txt
+        # Assert CloudknotInputError to prevent overwriting existing
+        # requirements.txt
         # First, avoid the existing Dockerfile error by renaming the Dockerfile
         old_dockerfile = op.join(op.dirname(correct_script_path), 'Dockerfile')
 


### PR DESCRIPTION
This PR removes the circular error checking in cloudknot configure.

Previously, cloudknot configure imported parts of cloudknot, thereby running the code in `cloudknot/__init__.py`. We also had some error checking in `__init__.py` that would check whether or not cloudknot had been configured. Naturally, it was difficult to satisfy the configuration requirement before running `cloudknot configure`. So the old solution was to analyze the stack and determine whether or not the interpreter had arrived at the `__init__.py` statements from an import or from the cloudknot CLI. This was not a satisfactory solution since it was hard to generalize to the stack frame contexts on every user's system.

This PR resolves this issue by moving the configuration error checking into the `__init__` method of the `NamedObject` base class, thereby checking before instantiating `Knot`, `Pars`, `IamRole`, etc.

This PR also creates the `CloudknotInputError` exception to replace all of the old `ValueError`s, which were too generic.

Resolves #124 
Addresses #113