### PR TITLE
Wildcard down into the data folder for setup installation

### DIFF
--- a/cloudknot/version.py
+++ b/cloudknot/version.py
@@ -71,7 +71,8 @@ MAJOR = _version_major
 MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
-PACKAGE_DATA = {'cloudknot': [pjoin('data', '*'), pjoin('templates', '*')]}
+PACKAGE_DATA = {'cloudknot': [pjoin('data', '*', '*', '*', '*'),
+			      pjoin('templates', '*')]}
 REQUIRES = ["awscli", "boto3", "cloudpickle", "docker", "pipreqs",
             "six", "tenacity", 'configparser;python_version<"3.0"']
 EXTRAS_REQUIRE = {':python_version < "3.0"': ["configparser"]}


### PR DESCRIPTION
Without this fix, I was running into: 

    error: can't copy 'cloudknot/data/docker_reqs_ref_data': doesn't exist or not a regular file

When running a `sudo python setup.py install` on an AWS linux machine.